### PR TITLE
Update rockspec dependencies to work with lua 5.3

### DIFF
--- a/ldbus-scm-0.rockspec
+++ b/ldbus-scm-0.rockspec
@@ -9,7 +9,7 @@ description = {
 	 license = "MIT/X11"
 }
 dependencies = {
-	 "lua >= 5.1, < 5.3"
+	 "lua >= 5.1, < 5.4"
 }
 external_dependencies = {
 	DBUS = { header = "dbus/dbus.h" },


### PR DESCRIPTION
Related to https://github.com/dodo/lua-mpris/issues/2
